### PR TITLE
Add missing Prettier plugin to Yarn installation

### DIFF
--- a/packages/prettier-plugin-toml/README.md
+++ b/packages/prettier-plugin-toml/README.md
@@ -12,7 +12,7 @@ Please try it out and provide feedback.
 yarn:
 
 ```bash
-yarn add --dev prettier  --dev --exact
+yarn add --dev prettier prettier-plugin-toml --dev --exact
 ```
 
 npm:


### PR DESCRIPTION
Manual test as follows:

```bash
$ docker run -it --rm alpine:3.10.3
/ # apk add yarn
…
(8/8) Installing yarn (1.16.0-r0)
…
/ # yarn add --dev prettier prettier-plugin-toml --dev --exact
…
info Direct dependencies
├─ prettier-plugin-toml@0.3.1
└─ prettier@1.19.1
…
/ # echo 'foo  =  "bar"' | node_modules/.bin/prettier --stdin-filepath main.toml
foo = "bar"
```